### PR TITLE
fix to catch last entites

### DIFF
--- a/nervaluate/utils.py
+++ b/nervaluate/utils.py
@@ -84,7 +84,7 @@ def collect_named_entities(tokens):
 
     # catches an entity that goes up until the last token
 
-    if ent_type and start_offset and end_offset is None:
+    if ent_type is not None and start_offset is not None and end_offset is None:
         named_entities.append({"label": ent_type, "start": start_offset, "end":len(tokens)-1})
 
     return named_entities

--- a/nervaluate/utils.py
+++ b/nervaluate/utils.py
@@ -82,7 +82,7 @@ def collect_named_entities(tokens):
             start_offset = offset
             end_offset = None
 
-    # catches an entity that goes up until the last token
+    # Catches an entity that goes up until the last token
 
     if ent_type is not None and start_offset is not None and end_offset is None:
         named_entities.append({"label": ent_type, "start": start_offset, "end":len(tokens)-1})


### PR DESCRIPTION
Small change to catch entities that go up until last character when there is no tag (i.e. it is an '' (empty string) which will evaluate to False)